### PR TITLE
Doc: upstream table name prefixed with database name

### DIFF
--- a/integrations/sources/sql-server-cdc.mdx
+++ b/integrations/sources/sql-server-cdc.mdx
@@ -76,7 +76,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
 );
 ```
 
-Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table. Also, the upstream table name should be prefixed with database name.
+Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
 
 ```sql
 CREATE TABLE [ IF NOT EXISTS ] table_name (
@@ -87,7 +87,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 WITH (
     snapshot='true'
 )
-FROM source TABLE database_name.table_name;
+FROM source TABLE sqlserver_table_name;
 ```
 
 Although SQL Server is case-insensitive in most cases, to avoid potential issues, please ensure that the case of the schema names, table names, and column names in RisingWave and SQL Server is consistent.
@@ -97,13 +97,14 @@ Although SQL Server is case-insensitive in most cases, to avoid potential issues
 Unless specified otherwise, the fields listed are required. Note that the value of these parameters should be enclosed in single quotation marks.
 
 | Field         | Notes                        |
-| ------------- | ---------------------------- |
+| :------------ | :--------------------------- |
 | hostname      | Hostname of the database.    |
 | port          | Port number of the database. |
 | username      | Username of the database.    |
 | password      | Password of the database.    |
 | database.name | Name of the database.        |
 |database.encrypt| Optional. Specify whether to enable SSL encryption. Currently, `trustServerCertificate` is enabled regardless of the value of `database.encrypt`. |
+| sqlserver_table_name | The identifier of SQL Server table in the format of `database_name.schema_name.table_name`. |
 
 <Info>
 **NOTE**
@@ -115,8 +116,8 @@ Additionally, unlike MySQL and PostgreSQL, the SQL Server CDC connector does not
 
 The following fields are used when creating a CDC table.
 
-| Field                | Notes                                                                                                                                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Field                | Notes               |
+| :------------------- | :--------------------------- |
 | snapshot             | Optional. If false, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
 | snapshot.interval    | Optional. Specifies the barrier interval for buffering upstream events. The default value is 1.                                                                                                                          |
 | snapshot.batch\_size | Optional. Specifies the batch size of a snapshot read query from the upstream table. The default value is 1000.                                                                                                          |
@@ -163,7 +164,7 @@ Data is in Debezium JSON format. [Debezium](https://debezium.io) is a log-based 
 Below are the metadata columns available for SQL Server CDC.
 
 | Field          | Notes                 |
-| -------------- | --------------------- |
+| :------------- | :-------------------- |
 | database\_name | Name of the database. |
 | schema\_name   | Name of the schema.   |
 | table\_name    | Name of the table.    |
@@ -182,7 +183,7 @@ CREATE TABLE person (
 INCLUDE DATABASE_NAME as database_name
 INCLUDE SCHEMA_NAME as schema_name
 INCLUDE TABLE_NAME as table_name
-FROM mssql_source TABLE 'dbo.person';
+FROM mssql_source TABLE 'mydb.dbo.person';
 ```
 
 ## Examples
@@ -229,8 +230,8 @@ The following table shows the corresponding data type in RisingWave that should 
 
 RisingWave data types marked with an asterisk indicate that while there is no corresponding RisingWave data type, the ingested data can still be consumed as the listed type.
 
-| SQL Server type                                                                                           | RisingWave type                                                                                                                     |
-| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| SQL Server type   | RisingWave type          |
+| :------- | :--------------------- |
 | BIT                                                                                                       | BOOLEAN                                                                                                                             |
 | TINYINT, SMALLINT                                                                                         | SMALLINT                                                                                                                            |
 | INT                                                                                                       | INTEGER                                                                                                                             |

--- a/integrations/sources/sql-server-cdc.mdx
+++ b/integrations/sources/sql-server-cdc.mdx
@@ -76,7 +76,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
 );
 ```
 
-Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
+Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table. Also, the upstream table name should be prefixed with database name.
 
 ```sql
 CREATE TABLE [ IF NOT EXISTS ] table_name (
@@ -87,7 +87,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 WITH (
     snapshot='true'
 )
-FROM source TABLE table_name;
+FROM source TABLE database_name.table_name;
 ```
 
 Although SQL Server is case-insensitive in most cases, to avoid potential issues, please ensure that the case of the schema names, table names, and column names in RisingWave and SQL Server is consistent.
@@ -136,7 +136,7 @@ SELECT * FROM t2 ORDER BY v1;
   4 | dd | 2024-05-20 09:01:08+00:00
 ```
 
-#### Debezium parameters
+### Debezium parameters
 
 [Debezium v2.6 connector configuration properties](https://debezium.io/documentation/reference/2.6/connectors/sqlserver.html#sqlserver-advanced-connector-configuration-properties) can also be specified under the `WITH` clause when creating a table or shared source. Add the prefix `debezium.` to the connector property you want to include.
 

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -34,40 +34,54 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 
 ## Notes
 
-For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
+- For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
 
-A [generated column](/docs/current/query-syntax-generated-columns/) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
+- A [generated column](/docs/current/query-syntax-generated-columns/) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
 
-Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive. See also [Identifiers](/docs/current/sql-identifiers/).
+- Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive. See also [Identifiers](/docs/current/sql-identifiers/).
 
-The syntax for creating a table with connector settings and the supported connectors are the same as for creating a source. See [CREATE SOURCE](/docs/current/sql-create-source/) for a full list of supported connectors and data formats.
+- The syntax for creating a table with connector settings and the supported connectors are the same as for creating a source. See [CREATE SOURCE](/docs/current/sql-create-source/) for a full list of supported connectors and data formats.
 
-To know when a data record is loaded to RisingWave, you can define a column that is generated based on the processing time (`<column_name> timestamptz AS proctime()`) when creating the table or source. See also [proctime()](/docs/current/sql-function-datetime/#proctime).
+- To know when a data record is loaded to RisingWave, you can define a column that is generated based on the processing time (`<column_name> timestamptz AS proctime()`) when creating the table or source. See also [proctime()](/docs/current/sql-function-datetime/#proctime).
 
-For a table with schema from external connector, use `*` to represent all columns from the external connector first, so that you can define a generated column on table with an external connector. See the example below.
+- For a table with schema from external connector, use `*` to represent all columns from the external connector first, so that you can define a generated column on table with an external connector. See the example below
 
-```js
-CREATE TABLE from_kafka (
-  *,
-  gen_i32_field INT AS int32_field + 2,
-  PRIMARY KEY (some_key)
-)
-INCLUDE KEY AS some_key
-[INCLUDE { header | offset | partition | timestamp } [AS <column_name>]]
-WITH (
-  connector = 'kafka',
-  topic = 'test-rw-sink-upsert-avro',
-  properties.bootstrap.server = 'message_queue:29092'
-)
-FORMAT upsert ENCODE AVRO (
-  schema.registry = 'http://message_queue:8081'
-);
-```
+  ```sql
+  CREATE TABLE from_kafka (
+    *,
+    gen_i32_field INT AS int32_field + 2,
+    PRIMARY KEY (some_key)
+  )
+  INCLUDE KEY AS some_key
+  [INCLUDE { header | offset | partition | timestamp } [AS <column_name>]]
+  WITH (
+    connector = 'kafka',
+    topic = 'test-rw-sink-upsert-avro',
+    properties.bootstrap.server = 'message_queue:29092'
+  )
+  FORMAT upsert ENCODE AVRO (
+    schema.registry = 'http://message_queue:8081'
+  );
+  ```
+
+- When creating a CDC table, the upstream table name should be prefixed with database name. See the example below:
+
+  ```sql
+  CREATE TABLE shared_orders (
+      order_id INT,
+      order_date BIGINT,
+      customer_name VARCHAR,
+      price DECIMAL,
+      product_id INT,
+      order_status SMALLINT,
+      PRIMARY KEY (order_id)
+  )  from mssql_source table 'mydb.dbo.wrong_orders';
+  ```
 
 ## Parameters
 
-| Parameter or clause               | Description                                                                                                                                                                                                                                                                                                                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter or clause               | Description   |
+| :-------------------------------- | :------------ |
 | table\_name                       | The name of the table. If a schema name is given (for example, CREATE TABLE \<schema>.\<table> ...), then the table is created in the specified schema. Otherwise it is created in the current schema.                                                                                                                                                                                                    |
 | col\_name                         | The name of a column.                                                                                                                                                                                                                                                                                                                                                                                   |
 | data\_type                        | The data type of a column. With the struct data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets (\<>).                                                                                                                                                                                                                                           |

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -64,20 +64,6 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
   );
   ```
 
-- When creating a CDC table, the upstream table name should be prefixed with database name. See the example below:
-
-  ```sql
-  CREATE TABLE shared_orders (
-      order_id INT,
-      order_date BIGINT,
-      customer_name VARCHAR,
-      price DECIMAL,
-      product_id INT,
-      order_status SMALLINT,
-      PRIMARY KEY (order_id)
-  )  from mssql_source table 'mydb.dbo.wrong_orders';
-  ```
-
 ## Parameters
 
 | Parameter or clause               | Description   |


### PR DESCRIPTION
## Description
Upstream table name needs to be prefixed with database name

## Related code PR 
https://github.com/risingwavelabs/risingwave/pull/18868

## Related doc issue
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2690

## Preview

<img width="767" alt="image" src="https://github.com/user-attachments/assets/2c52370c-f39f-4863-a484-cd9c6287cc05">

